### PR TITLE
Fix the alignment of Chinese characters when "…

### DIFF
--- a/nb_cli/utils.py
+++ b/nb_cli/utils.py
@@ -123,8 +123,9 @@ def print_package_results(hits: Union[List[Plugin], List[Adapter]],
         return
 
     if name_column_width is None:
-        name_column_width = max(
-            [len(f"{hit.name} ({hit.link})") for hit in hits]) + 4
+        name_column_width = (
+            max([len(f"{hit.name} ({hit.link})".encode("gbk")) for hit in hits]) + 4
+        )
     if terminal_width is None:
         terminal_width = shutil.get_terminal_size()[0]
 
@@ -134,10 +135,14 @@ def print_package_results(hits: Union[List[Plugin], List[Adapter]],
         target_width = terminal_width - name_column_width - 5
         if target_width > 10:
             # wrap and indent summary to fit terminal
-            summary_lines = textwrap.wrap(summary, target_width)
+            summary_lines=[]
+            while len(summary.encode('gbk')) > target_width:
+                summary_lines.append(summary[:target_width])
+                summary = summary[len(summary_lines) * target_width + 1:]
+            if not summary_lines:summary_lines=[summary]
             summary = ("\n" + " " * (name_column_width + 3)).join(summary_lines)
 
-        line = f"{name:{name_column_width}} - {summary}"
+        line = f"{name + ' ' * (name_column_width-len(name.encode('gbk')))} - {summary}"
         try:
             print(line)
         except UnicodeEncodeError:


### PR DESCRIPTION
众所周知，汉字在等宽字体里的宽度是英文字母的两倍，所以在 nb-cli 中使用 `List All Published ...` 时，如果插件的名称或简介含有汉字，插件列表就无法正常对齐，出现一定程度的错位。

又众所周知，gbk 编码的字符串中汉字占据的长度是英文字母的两倍，所以我简单粗暴地通过计算字符串被 gbk 编码后的长度得出了正确的填充空格数。

**修复前:：**

```
服务器状态查看 (nonebot-plugin-status)                       - 通过戳一戳获取服务器状态
HarukaBot (haruka-bot)                                - 将B站UP主的动态和直播信息推送至QQ
rauthman (nonebot-plugin-rauthman)                    - 基于规则的授权管理
NoneBot离线文档 (nonebot-plugin-docs)                     - 在本地浏览NoneBot文档
Sentry日志监控 (nonebot-plugin-sentry)                    - 使用Sentry监控机器人日志并处理报错
前端测试机器人插件 (nonebot-plugin-test)                       - 在浏览器中测试你的 NoneBot 机器人        
定时任务 (nonebot-plugin-apscheduler)                     - APScheduler 定时任务插件
图片搜索 (nonebot-plugin-picsearcher)                     - 从基本上所有你想的出名字的搜图平台找图片      
通用数据库连接 (nonebot-plugin-navicat)                      - 连接至各种数据库,为其他插件导出连接对象    
translator (nonebot-plugin-translator)                - 多语种翻译插件
模拟抽卡 (nonebot-plugin-simdraw)                         - 根据配置的手游卡池信息模拟抽卡
nonebot-plugin-wordbank (nonebot-plugin-wordbank)     - 无数据库的轻量问答插件，支持模糊问答
冷却事件 (nonebot-plugin-cooldown)                        - 为用户调用功能添加冷却时间（调用频率限制）功能
mqtt接入 (nonebot-plugin-mqtt)                          - 接入mqtt网络,订阅和发布消息
消息交互式 python 解释器 (nonebot-plugin-ipypreter)           - 消息交互式 python 解释器
songpicker2 (nonebot-plugin-songpicker2)              - 点播歌曲，支持候选菜单、热评显示，数据源为网易云
风格化字符串管理 (nonebot-plugin-styledstr)                   - 通过字符串标签管理字符串资源
Arcaea 查分器 (nonebot-plugin-arcaea)                    - Arcaea 查分器，可以实现 best30 | recent | songinfo 之类的查询功能并支持 DIY
hk-reporter (nonebot-hk-reporter)                     - 订阅如微博，bilibili，rss的更新消息
网易云无损音乐下载 (nonebot-plugin-ncm)                        - 网易云无损音乐下载
nonebot-plugin-cocdicer (nonebot-plugin-cocdicer)     - COC跑团骰子娘
跑团记录记录器 (nonebot-plugin-trpglogger)                   - 记录跑团记录并上传
nonebot-plugin-r6s (nonebot-plugin-r6s)               - 查询彩虹六号玩家信息
猜猜看 (nonebot-plugin-guess)                            - 多次互动猜名字游戏，自带猜城市名，可定制
缩写查询器 (nonebot_plugin_abbrreply)                      - 输入拼音首字母，猜测文字
biliav小程序转换器 (nonebot_plugin_biliav)                  - 将用户发的av号或者bv号转成小程序返回
插件管理器 (nonebot-plugin-manager)                        - 基于 import hook 的插件管理
```

**修复后：**

```
服务器状态查看 (nonebot-plugin-status)                  - 通过戳一戳获取服务器状态
HarukaBot (haruka-bot)                                  - 将B站UP主的动态和直播信息推送至QQ
rauthman (nonebot-plugin-rauthman)                      - 基于规则的授权管理
NoneBot离线文档 (nonebot-plugin-docs)                   - 在本地浏览NoneBot文档
Sentry日志监控 (nonebot-plugin-sentry)                  - 使用Sentry监控机器人日志并处理报错
前端测试机器人插件 (nonebot-plugin-test)                - 在浏览器中测试你的 NoneBot 机器人
定时任务 (nonebot-plugin-apscheduler)                   - APScheduler 定时任务插件
图片搜索 (nonebot-plugin-picsearcher)                   - 从基本上所有你想的出名字的搜图平台找图片      
通用数据库连接 (nonebot-plugin-navicat)                 - 连接至各种数据库,为其他插件导出连接对象       
translator (nonebot-plugin-translator)                  - 多语种翻译插件
模拟抽卡 (nonebot-plugin-simdraw)                       - 根据配置的手游卡池信息模拟抽卡
nonebot-plugin-wordbank (nonebot-plugin-wordbank)       - 无数据库的轻量问答插件，支持模糊问答
冷却事件 (nonebot-plugin-cooldown)                      - 为用户调用功能添加冷却时间（调用频率限制）功能
mqtt接入 (nonebot-plugin-mqtt)                          - 接入mqtt网络,订阅和发布消息
消息交互式 python 解释器 (nonebot-plugin-ipypreter)     - 消息交互式 python 解释器
songpicker2 (nonebot-plugin-songpicker2)                - 点播歌曲，支持候选菜单、热评显示，数据源为网易云
风格化字符串管理 (nonebot-plugin-styledstr)             - 通过字符串标签管理字符串资源
Arcaea 查分器 (nonebot-plugin-arcaea)                   - Arcaea 查分器，可以实现 best30 | recent | songinfo 之类的查询功能并支持 DIY
hk-reporter (nonebot-hk-reporter)                       - 订阅如微博，bilibili，rss的更新消息
网易云无损音乐下载 (nonebot-plugin-ncm)                 - 网易云无损音乐下载
nonebot-plugin-cocdicer (nonebot-plugin-cocdicer)       - COC跑团骰子娘
跑团记录记录器 (nonebot-plugin-trpglogger)              - 记录跑团记录并上传
nonebot-plugin-r6s (nonebot-plugin-r6s)                 - 查询彩虹六号玩家信息
猜猜看 (nonebot-plugin-guess)                           - 多次互动猜名字游戏，自带猜城市名，可定制
缩写查询器 (nonebot_plugin_abbrreply)                   - 输入拼音首字母，猜测文字
biliav小程序转换器 (nonebot_plugin_biliav)              - 将用户发的av号或者bv号转成小程序返回
插件管理器 (nonebot-plugin-manager)                     - 基于 import hook 的插件管理
```